### PR TITLE
Fix colgroup span settings

### DIFF
--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -31,18 +31,10 @@ export default function Sudoku(props) {
 function Grid() {
     return (
         <table>
-            <colgroup>
-                <col />
-            </colgroup>
-            <colgroup className="region">
-                <col span="3" />
-            </colgroup>
-            <colgroup className="region">
-                <col span="3" />
-            </colgroup>
-            <colgroup className="region">
-                <col span="3" />
-            </colgroup>
+            <colgroup span="1" />
+            <colgroup className="region" span="3" />
+            <colgroup className="region" span="3" />
+            <colgroup className="region" span="3" />
 
             <HeaderRow />
             <tbody className="region">
@@ -106,18 +98,10 @@ function Cell(props) {
 function DebugGrid() {
     return (
         <table>
-            <colgroup>
-                <col />
-            </colgroup>
-            <colgroup className="region">
-                <col span="3" />
-            </colgroup>
-            <colgroup className="region">
-                <col span="3" />
-            </colgroup>
-            <colgroup className="region">
-                <col span="3" />
-            </colgroup>
+            <colgroup span="1" />
+            <colgroup className="region" span="3" />
+            <colgroup className="region" span="3" />
+            <colgroup className="region" span="3" />
 
             <HeaderRow />
             <tbody className="region">


### PR DESCRIPTION
Safari was not rendering the colgroups correctly, in that every column had thicker borders instead of just every 3rd column.