### PR TITLE
Overhauled gridReducer to recalculate availableValues

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.1.0",
     "@testing-library/user-event": "^13.2.1",
+    "assert": "^2.0.0",
     "gh-pages": "^3.2.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/sudoku/CellState.js
+++ b/src/sudoku/CellState.js
@@ -1,3 +1,4 @@
+import assert from "assert";
 import {GRID_SIZE, REGION_SIZE} from "./Grid";
 
 const AVAILABLE_VALUES = [1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -9,9 +10,8 @@ export default class CellState {
 
         if (readOnly) {
             this.readOnly = true;
-            if (errors || availableValues) {
-                throw new Error(`readOnly cell should not have errors or availableValues ${errors} or ${availableValues}`);
-            }
+            assert(!errors, `readOnly cell should not have errors '${errors}'`);
+            assert(!availableValues, `readOnly cell should not have availableValues '${availableValues}'`);
         } else {
             this.errors = errors !== undefined ? errors : {row: 0, column: 0, region: 0, total: 0};
             if (isNaN(this.value)) {

--- a/src/sudoku/CellState.js
+++ b/src/sudoku/CellState.js
@@ -46,34 +46,16 @@ export default class CellState {
         return (this.regionRow * REGION_SIZE) + this.regionColumn;
     }
 
-    setError(segmentType) {
-        if (this.errors[segmentType]) {
-            throw new Error(`Error has already been set for segment type ${segmentType}`);
-        }
-        this.errors[segmentType] = 1;
-        this.errors.total += 1;
-    }
-
-    clearError(segmentType) {
-        if (!this.errors[segmentType]) {
-            throw new Error(`Error is not set for segment type ${segmentType}`);
-        }
-        this.errors[segmentType] = 0;
-        this.errors.total -= 1;
-    }
-
-    setAvailableValue(value) {
-        this.availableValues.clear();
-        this.availableValues.add(value);
-    }
-
-    addAvailableValue(value) {
-        this.availableValues.add(value);
-    }
-
-    removeAvailableValues(values) {
-        for (const value of values) {
-            this.availableValues.delete(value);
+    segment(segmentType) {
+        switch (segmentType) {
+            case 'row':
+                return this.row;
+            case 'column':
+                return this.column;
+            case 'region':
+                return this.region;
+            default:
+                throw new Error(`Unknown segment type '${segmentType}'`);
         }
     }
 }

--- a/src/sudoku/CellState.js
+++ b/src/sudoku/CellState.js
@@ -1,7 +1,7 @@
 import assert from "assert";
 import {GRID_SIZE, REGION_SIZE} from "./Grid";
 
-const AVAILABLE_VALUES = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+export const AVAILABLE_VALUES = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
 export default class CellState {
     constructor(index, value, readOnly, errors, availableValues) {
@@ -21,8 +21,8 @@ export default class CellState {
             }
         }
 
-        // Object.freeze(this.errors);
-        // Object.freeze(this.availableValues);
+        Object.freeze(this.errors);
+        Object.freeze(this.availableValues);
         Object.freeze(this);
     }
 

--- a/src/sudoku/DebugGrid.js
+++ b/src/sudoku/DebugGrid.js
@@ -13,7 +13,7 @@ function DebugGrid() {
             cells.push(cell);
         }
     }
-    return <Grid cells={cells}/>;
+    return <Grid className="sudoku debug" cells={cells}/>;
 }
 
 function DebugCell({index}) {

--- a/src/sudoku/DebugGrid.js
+++ b/src/sudoku/DebugGrid.js
@@ -1,8 +1,9 @@
 import React, {useContext} from "react";
+import PropTypes from "prop-types";
 import {GridContext} from "./Context";
 import Grid, {GRID_INDEXES, GRID_SIZE} from "./Grid";
 
-export default function DebugGrid() {
+function DebugGrid() {
     let cells = [];
     for (const row of GRID_INDEXES) {
         for (const col of GRID_INDEXES) {
@@ -15,9 +16,9 @@ export default function DebugGrid() {
     return <Grid cells={cells}/>;
 }
 
-function DebugCell(props) {
+function DebugCell({index}) {
     const grid = useContext(GridContext);
-    const cell = grid.cells[props.index];
+    const cell = grid.cells[index];
 
     if (!isNaN(cell.value)) {
         if (cell.readOnly) {
@@ -32,3 +33,9 @@ function DebugCell(props) {
         </td>
     );
 }
+
+DebugCell.propTypes = {
+    index: PropTypes.number
+};
+
+export default DebugGrid;

--- a/src/sudoku/Grid.js
+++ b/src/sudoku/Grid.js
@@ -1,4 +1,6 @@
-export default function Grid(props) {
+import PropTypes from "prop-types";
+
+function Grid({cells}) {
     return (
         <table>
             <colgroup span="1"/>
@@ -8,19 +10,19 @@ export default function Grid(props) {
 
             <HeaderRow/>
             <tbody className="region">
-            <Row row={0} cells={props.cells}/>
-            <Row row={1} cells={props.cells}/>
-            <Row row={2} cells={props.cells}/>
+            <Row row={0} cells={cells}/>
+            <Row row={1} cells={cells}/>
+            <Row row={2} cells={cells}/>
             </tbody>
             <tbody className="region">
-            <Row row={3} cells={props.cells}/>
-            <Row row={4} cells={props.cells}/>
-            <Row row={5} cells={props.cells}/>
+            <Row row={3} cells={cells}/>
+            <Row row={4} cells={cells}/>
+            <Row row={5} cells={cells}/>
             </tbody>
             <tbody className="region">
-            <Row row={6} cells={props.cells}/>
-            <Row row={7} cells={props.cells}/>
-            <Row row={8} cells={props.cells}/>
+            <Row row={6} cells={cells}/>
+            <Row row={7} cells={cells}/>
+            <Row row={8} cells={cells}/>
             </tbody>
         </table>
     );
@@ -45,16 +47,26 @@ function HeaderRow() {
     );
 }
 
-function Row(props) {
-    const rowLabel = "ABCDEFGHI".charAt(props.row);
-    const rowStartIdx = props.row * GRID_SIZE;
+function Row({row, cells}) {
+    const rowLabel = "ABCDEFGHI".charAt(row);
+    const rowStartIdx = row * GRID_SIZE;
     return (
         <tr>
             <th scope="row">{rowLabel}</th>
             {GRID_INDEXES.map((col) => {
                 const cellIdx = rowStartIdx + col;
-                return props.cells[cellIdx];
+                return cells[cellIdx];
             })}
         </tr>
     );
 }
+
+Grid.propTypes = {
+    cells: PropTypes.arrayOf(PropTypes.element),
+};
+Row.propTypes = {
+    row: PropTypes.number,
+    cells: PropTypes.arrayOf(PropTypes.element),
+};
+
+export default Grid;

--- a/src/sudoku/Grid.js
+++ b/src/sudoku/Grid.js
@@ -1,30 +1,32 @@
 import PropTypes from "prop-types";
 
-function Grid({cells}) {
+function Grid({cells, className}) {
     return (
-        <table>
-            <colgroup span="1"/>
-            <colgroup className="region" span="3"/>
-            <colgroup className="region" span="3"/>
-            <colgroup className="region" span="3"/>
+        <div className={className}>
+            <table>
+                <colgroup span="1"/>
+                <colgroup className="region" span="3"/>
+                <colgroup className="region" span="3"/>
+                <colgroup className="region" span="3"/>
 
-            <HeaderRow/>
-            <tbody className="region">
-            <Row row={0} cells={cells}/>
-            <Row row={1} cells={cells}/>
-            <Row row={2} cells={cells}/>
-            </tbody>
-            <tbody className="region">
-            <Row row={3} cells={cells}/>
-            <Row row={4} cells={cells}/>
-            <Row row={5} cells={cells}/>
-            </tbody>
-            <tbody className="region">
-            <Row row={6} cells={cells}/>
-            <Row row={7} cells={cells}/>
-            <Row row={8} cells={cells}/>
-            </tbody>
-        </table>
+                <HeaderRow/>
+                <tbody className="region">
+                <Row row={0} cells={cells}/>
+                <Row row={1} cells={cells}/>
+                <Row row={2} cells={cells}/>
+                </tbody>
+                <tbody className="region">
+                <Row row={3} cells={cells}/>
+                <Row row={4} cells={cells}/>
+                <Row row={5} cells={cells}/>
+                </tbody>
+                <tbody className="region">
+                <Row row={6} cells={cells}/>
+                <Row row={7} cells={cells}/>
+                <Row row={8} cells={cells}/>
+                </tbody>
+            </table>
+        </div>
     );
 }
 
@@ -63,6 +65,7 @@ function Row({row, cells}) {
 
 Grid.propTypes = {
     cells: PropTypes.arrayOf(PropTypes.element),
+    className: PropTypes.string,
 };
 Row.propTypes = {
     row: PropTypes.number,

--- a/src/sudoku/GridState.js
+++ b/src/sudoku/GridState.js
@@ -24,7 +24,7 @@ export default class GridState {
         // Add each cell incrementally so the availableValues can be kept up-to-date
         for (const cell of cells) {
             if (!isNaN(cell.value)) {
-                grid = gridReducer(grid, new SetValueAction(cell.index, cell.value, true));
+                grid = gridReducer(grid, new SetValueAction(cell.index, cell.value, cells, true));
             }
         }
         return grid;

--- a/src/sudoku/GridState.js
+++ b/src/sudoku/GridState.js
@@ -10,11 +10,10 @@ export default class GridState {
         } else {
             this.cells = cells;
         }
-
         assert(this.cells.length === GRID_SIZE ** 2,
             `Grid has incorrect number of cells '${this.cells.length}'`);
 
-        // Object.freeze(this.cells);
+        Object.freeze(this.cells);
         Object.freeze(this);
     }
 

--- a/src/sudoku/GridState.js
+++ b/src/sudoku/GridState.js
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import CellState from './CellState';
 import {gridReducer, SetValueAction} from './gridReducer';
 import {GRID_INDEXES, GRID_SIZE} from "./Grid";
@@ -10,9 +11,8 @@ export default class GridState {
             this.cells = cells;
         }
 
-        if (this.cells.length !== GRID_SIZE ** 2) {
-            throw new Error(`Grid must contain 81 cells: got ${cells.length}`);
-        }
+        assert(this.cells.length === GRID_SIZE ** 2,
+            `Grid has incorrect number of cells '${this.cells.length}'`);
 
         // Object.freeze(this.cells);
         Object.freeze(this);

--- a/src/sudoku/GridState.js
+++ b/src/sudoku/GridState.js
@@ -1,6 +1,6 @@
 import CellState from './CellState';
 import {gridReducer, SetValueAction} from './gridReducer';
-import {GRID_INDEXES, GRID_SIZE, REGION_INDEXES, REGION_SIZE} from "./Grid";
+import {GRID_INDEXES, GRID_SIZE} from "./Grid";
 
 export default class GridState {
     constructor(cells) {
@@ -49,77 +49,5 @@ export default class GridState {
             }
             return new CellState(idx, val, !isNaN(val));
         });
-    }
-
-    row(rowIndex) {
-        const startIdx = rowIndex * GRID_SIZE;
-        const cells = GRID_INDEXES.map((offset) => this.cells[startIdx + offset]);
-        return new SegmentState('row', rowIndex, cells);
-    }
-
-    column(columnIndex) {
-        const cells = GRID_INDEXES.map((row) => this.cells[(row * GRID_SIZE) + columnIndex]);
-        return new SegmentState('column', columnIndex, cells);
-    }
-
-    region(regionIndex) {
-        const regionRow = Math.trunc(regionIndex / REGION_SIZE);
-        const regionCol = regionIndex % REGION_SIZE;
-
-        const cells = REGION_INDEXES.flatMap((rowOffset) => {
-            const row = (regionRow * REGION_SIZE) + rowOffset;
-            return REGION_INDEXES.map((colOffset) => {
-                const col = (regionCol * REGION_SIZE) + colOffset;
-                const index = (row * GRID_SIZE) + col;
-                return this.cells[index];
-            });
-        });
-        return new SegmentState('region', regionIndex, cells);
-    }
-
-    segment(segmentType, segmentIndex) {
-        switch (segmentType) {
-            case 'row':
-                return this.row(segmentIndex);
-            case 'column':
-                return this.column(segmentIndex);
-            case 'region':
-                return this.region(segmentIndex);
-            default:
-                throw new Error(`Unknown segment type '${segmentType}'`);
-        }
-    }
-}
-
-class SegmentState {
-    constructor(type, index, cells) {
-        this.type = type;
-        this.index = index;
-        this.cells = cells;
-    }
-
-    get values() {
-        return this.cells
-            .map((cell) => cell.value)
-            .filter((value) => !isNaN(value));
-    }
-
-    get cellsByAvailableValue() {
-        return this._cellsByAvailableValue = this._cellsByAvailableValue
-            || this.cells.reduce((acc, cell) => {
-                if (isNaN(cell.value)) {
-                    for (const value of cell.availableValues) {
-                        if (!acc.has(value)) {
-                            acc.set(value, []);
-                        }
-                        acc.get(value).push(cell);
-                    }
-                }
-                return acc;
-            }, new Map());
-    }
-
-    isValueAvailable(value) {
-        return this.cellsByAvailableValue.has(value);
     }
 }

--- a/src/sudoku/GridState.js
+++ b/src/sudoku/GridState.js
@@ -20,7 +20,7 @@ export default class GridState {
 
     static newFrom(gridString) {
         let grid = new GridState();
-        const cells = grid._parseGrid(gridString);
+        const cells = grid._parseGridString(gridString);
         // Add each cell incrementally so the availableValues can be kept up-to-date
         for (const cell of cells) {
             if (!isNaN(cell.value)) {
@@ -39,7 +39,7 @@ export default class GridState {
         );
     }
 
-    _parseGrid(gridString) {
+    _parseGridString(gridString) {
         const values = (gridString).split('');
         return values.map((val, idx) => {
             if (!val || val < 1) {

--- a/src/sudoku/PuzzleGrid.js
+++ b/src/sudoku/PuzzleGrid.js
@@ -31,7 +31,7 @@ function Cell({index}) {
                 type="number" min="1" max="9" maxLength="1"
                 value={cell.value ? cell.value : ''}
                 onChange={(event) => (
-                    dispatch(new SetValueAction(cell.index, event.target.valueAsNumber))
+                    dispatch(new SetValueAction(cell.index, event.target.valueAsNumber, grid.cells))
                 )}
                 className={`${cell.availableValues.size === 1 ? 'hint' : ''} ${cell.errors.total > 0 ? 'error' : ''}`}
             />

--- a/src/sudoku/PuzzleGrid.js
+++ b/src/sudoku/PuzzleGrid.js
@@ -1,9 +1,10 @@
 import {useContext} from "react";
+import PropTypes from "prop-types";
 import {DispatchContext, GridContext} from "./Context";
 import Grid, {GRID_INDEXES, GRID_SIZE} from "./Grid";
 import {SetValueAction} from "./gridReducer";
 
-export default function PuzzleGrid() {
+function PuzzleGrid() {
     let cells = [];
     for (const row of GRID_INDEXES) {
         for (const col of GRID_INDEXES) {
@@ -15,10 +16,10 @@ export default function PuzzleGrid() {
     return <Grid cells={cells}/>;
 }
 
-function Cell(props) {
+function Cell({index}) {
     const dispatch = useContext(DispatchContext);
     const grid = useContext(GridContext);
-    const cell = grid.cells[props.index];
+    const cell = grid.cells[index];
 
     if (cell.readOnly) {
         return <td className={'readonly'}>{cell.value}</td>;
@@ -37,3 +38,9 @@ function Cell(props) {
         </td>
     );
 }
+
+Cell.propTypes = {
+    index: PropTypes.number
+};
+
+export default PuzzleGrid;

--- a/src/sudoku/PuzzleGrid.js
+++ b/src/sudoku/PuzzleGrid.js
@@ -13,7 +13,7 @@ function PuzzleGrid() {
             cells.push(cell);
         }
     }
-    return <Grid cells={cells}/>;
+    return <Grid className="sudoku" cells={cells}/>;
 }
 
 function Cell({index}) {

--- a/src/sudoku/SegmentState.js
+++ b/src/sudoku/SegmentState.js
@@ -1,0 +1,73 @@
+import {GRID_INDEXES, GRID_SIZE, REGION_INDEXES, REGION_SIZE} from "./Grid";
+
+export default class SegmentState {
+    static newFrom(gridCells, segmentIndex, segmentType) {
+        switch (segmentType) {
+            case 'row':
+                return row(gridCells, segmentIndex);
+            case 'column':
+                return column(gridCells, segmentIndex);
+            case 'region':
+                return region(gridCells, segmentIndex);
+            default:
+                throw new Error(`Unknown segment type '${segmentType}'`);
+        }
+    }
+
+    constructor(type, index, cells) {
+        this.type = type;
+        this.index = index;
+        this.cells = cells;
+    }
+
+    get values() {
+        return this.cells
+            .map((cell) => cell.value)
+            .filter((value) => !isNaN(value));
+    }
+
+    get cellsByAvailableValue() {
+        return this._cellsByAvailableValue = this._cellsByAvailableValue
+            || this.cells.reduce((acc, cell) => {
+                if (isNaN(cell.value)) {
+                    for (const value of cell.availableValues) {
+                        if (!acc.has(value)) {
+                            acc.set(value, []);
+                        }
+                        acc.get(value).push(cell);
+                    }
+                }
+                return acc;
+            }, new Map());
+    }
+
+    isValueAvailable(value) {
+        return this.cellsByAvailableValue.has(value);
+    }
+}
+
+function row(gridCells, rowIndex) {
+    const startIdx = rowIndex * GRID_SIZE;
+    const cells = GRID_INDEXES.map((offset) => gridCells[startIdx + offset]);
+    return new SegmentState('row', rowIndex, cells);
+}
+
+function column(gridCells, columnIndex) {
+    const cells = GRID_INDEXES.map((row) => gridCells[(row * GRID_SIZE) + columnIndex]);
+    return new SegmentState('column', columnIndex, cells);
+}
+
+function region(gridCells, regionIndex) {
+    const regionRow = Math.trunc(regionIndex / REGION_SIZE);
+    const regionCol = regionIndex % REGION_SIZE;
+
+    const cells = REGION_INDEXES.flatMap((rowOffset) => {
+        const row = (regionRow * REGION_SIZE) + rowOffset;
+        return REGION_INDEXES.map((colOffset) => {
+            const col = (regionCol * REGION_SIZE) + colOffset;
+            const index = (row * GRID_SIZE) + col;
+            return gridCells[index];
+        });
+    });
+    return new SegmentState('region', regionIndex, cells);
+}

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -16,12 +16,8 @@ function Sudoku({gridString}) {
     return (
         <GridContext.Provider value={grid}>
             <DispatchContext.Provider value={dispatch}>
-                <div className="sudoku">
-                    <PuzzleGrid/>
-                </div>
-                <div className='sudoku debug'>
-                    <DebugGrid/>
-                </div>
+                <PuzzleGrid/>
+                <DebugGrid/>
             </DispatchContext.Provider>
         </GridContext.Provider>
     );

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -9,8 +9,9 @@ import './Sudoku.css';
 
 function Sudoku({gridString}) {
     const [grid, dispatch] = useReducer(
-        gridReducer,
-        GridState.newFrom(gridString),
+        gridReducer, gridString, GridState.newFrom
+        // The 3rd arg for lazy initialization prevents repeated calls to
+        // dispatch() on the initial cells
     );
 
     return (

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -1,4 +1,5 @@
 import React, {useReducer} from 'react';
+import PropTypes from "prop-types";
 import {DispatchContext, GridContext} from './Context';
 import DebugGrid from './DebugGrid';
 import PuzzleGrid from './PuzzleGrid';
@@ -6,11 +7,10 @@ import GridState from './GridState';
 import {gridReducer} from './gridReducer';
 import './Sudoku.css';
 
-export default function Sudoku(props) {
+function Sudoku({gridString}) {
     const [grid, dispatch] = useReducer(
         gridReducer,
-        props.gridString,
-        (gridString) => GridState.newFrom(gridString),
+        GridState.newFrom(gridString),
     );
 
     return (
@@ -20,9 +20,15 @@ export default function Sudoku(props) {
                     <PuzzleGrid/>
                 </div>
                 <div className='sudoku debug'>
-                    <DebugGrid />
+                    <DebugGrid/>
                 </div>
             </DispatchContext.Provider>
         </GridContext.Provider>
     );
 }
+
+Sudoku.propTypes = {
+    gridString: PropTypes.string
+};
+
+export default Sudoku;

--- a/src/sudoku/gridReducer.js
+++ b/src/sudoku/gridReducer.js
@@ -121,12 +121,13 @@ function cellReducer(cell, action) {
         throw new Error(`Attempted to modify readOnly cell ${cell.index}`);
     }
 
-    if (action.constructor === SetValueAction) {
-        const readOnly = action.readOnly; // true during init()
-        const errors = !readOnly && !isNaN(action.value) ? cell.errors : undefined;
-        return new CellState(action.index, action.value, readOnly, errors);
-        // We will update the error value separately
-    } else {
-        throw new Error(`Unknown action type ${action.type}`);
+    switch (action.constructor) {
+        case SetValueAction:
+            const readOnly = action.readOnly; // true during init()
+            const errors = !readOnly && !isNaN(action.value) ? cell.errors : undefined;
+            // We will update the error value separately
+            return new CellState(action.index, action.value, readOnly, errors);
+        default:
+            throw new Error(`Unknown action type ${action.type}`);
     }
 }

--- a/src/sudoku/gridReducer.js
+++ b/src/sudoku/gridReducer.js
@@ -3,9 +3,10 @@ import SegmentState from './SegmentState';
 import CellState from './CellState';
 import {SEGMENT_TYPES} from "./Grid";
 
-export function SetValueAction(index, value, readOnly) {
+export function SetValueAction(index, value, gridCells, readOnly) {
     this.index = index;
     this.value = value;
+    this.gridCells = gridCells;
     this.readOnly = readOnly || false;
 }
 

--- a/src/sudoku/gridReducer.js
+++ b/src/sudoku/gridReducer.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import GridState from './GridState';
 import SegmentState from './SegmentState';
-import CellState from './CellState';
+import CellState, {AVAILABLE_VALUES} from './CellState';
 import {SEGMENT_TYPES} from "./Grid";
 
 export function SetValueAction(index, value, gridCells, readOnly = false) {
@@ -28,14 +28,6 @@ export function gridReducer(grid, action) {
 }
 
 function cellsReducer(cells, action) {
-    if (!isNaN(action.value)) {
-        return setCellValue(cells, action);
-    } else {
-        return clearCellValue(cells, action);
-    }
-}
-
-function setCellValue(cells, action) {
     // Clone the cells array before modifying it
     const newCells = [...cells];
 
@@ -44,142 +36,88 @@ function setCellValue(cells, action) {
     const newCell = cellReducer(oldCell, action);
     newCells[action.index] = newCell;
 
+    // Recalculate availableValues for related cells
     for (const segmentType of SEGMENT_TYPES) {
         const segmentIndex = newCell.segment(segmentType);
         const segment = SegmentState.newFrom(cells, segmentIndex, segmentType);
 
-        // Update the availableValues of related cells by removing this used value
-        for (const cell of segment.cells) {
-            if (isNaN(cell.value) && cell.availableValues.has(action.value)) {
-                removeCellAvailableValues(cell, [action.value]);
-            }
-        }
-        eliminateAvailableValues(segment);
-
-        // Mark any errors if this new value has caused any
-        const valueCells = segment.cells
-            .filter(cell => cell.value === action.value);
-        if (valueCells.length > 1) {
-            for (const cell of valueCells) {
-                if (!cell.readOnly && !cell.errors[segmentType]) {
-                    setCellError(cell, segmentType);
-                }
+        for (const segmentCell of segment.cells) {
+            if (isNaN(segmentCell.value) && segmentCell.index !== action.index) {
+                newCells[segmentCell.index] = cellReducer(segmentCell, action);
             }
         }
     }
+
     return newCells;
-}
-
-function clearCellValue(cells, action) {
-    // Clone the cells array before modifying it
-    const newCells = [...cells];
-
-    // Update the cell according to the action
-    const oldCell = newCells[action.index];
-    const newCell = cellReducer(oldCell, action);
-    newCells[action.index] = newCell;
-
-    for (const segmentType of SEGMENT_TYPES) {
-        const segmentIndex = newCell[segmentType];
-        const segment = SegmentState.newFrom(cells, segmentIndex, segmentType);
-
-        // Re-calculate the availableValues for the cell that has been cleared
-        removeCellAvailableValues(newCell, segment.values);
-        // Add old value back to availableValues of related cells
-        relatedCell:
-            for (const cell of segment.cells) {
-                if (cell.readOnly) {
-                    continue;
-                }
-                for (const segmentType1 of SEGMENT_TYPES) {
-                    const segment1 = SegmentState.newFrom(newCells, cell[segmentType1], segmentType1);
-                    if (!segment1.isValueAvailable(oldCell.value)) {
-                        continue relatedCell;
-                    }
-                }
-                addCellAvailableValue(cell, oldCell.value);
-            }
-        eliminateAvailableValues(segment);
-
-        // Clear errors in related cells that have been resolved by clearing this cell
-        const valueCells = segment.cells
-            .filter((cell) => cell.value === oldCell.value);
-        if (valueCells.length === 1) { // More than 1 means it is still an error
-            for (const cell of valueCells) {
-                if (!cell.readOnly && cell.errors[segmentType]) {
-                    clearCellError(cell, segmentType);
-                }
-            }
-        }
-    }
-    return newCells;
-}
-
-function eliminateAvailableValues(segment) {
-    // Detect values that are available in one cell only
-    for (const [value, cells] of segment.cellsByAvailableValue) {
-        if (cells.length === 1) {
-            setCellAvailableValue(cells[0], value);
-        }
-    }
 }
 
 function cellReducer(cell, action) {
-    // console.log(cell, action);
-    if (cell.readOnly) {
-        throw new Error(`Attempted to modify readOnly cell ${cell.index}`);
-    }
+    assert(!cell.readOnly, `Should not reduce a readOnly cell '${cell}'`);
 
-    switch (action.constructor) {
-        case SetValueAction:
-            // We will update the error value separately
-            return new CellState(
-                action.index,
-                reduceCellValue(cell.value, action),
-                action.readOnly, // true during initialisation
-                !action.readOnly && !isNaN(action.value) ? cell.errors : undefined,
-                //availableValues
-            );
-        default:
-            throw new Error(`Unknown action type ${action.type}`);
-    }
-}
-
-function reduceCellValue(value, action) {
-    if (action.constructor === SetValueAction) {
-        return action.value;
+    if (cell.index === action.index) {
+        if (isNaN(action.value)) {
+            return clearCell(cell, action);
+        } else {
+            return setCell(cell, action);
+        }
     } else {
-        return value;
+        assert(isNaN(cell.value), `Should not refresh cell with value '${cell.value}'`);
+        return refreshCell(cell, action);
     }
 }
 
-function setCellError(cell, segmentType) {
-    if (cell.errors[segmentType]) {
-        throw new Error(`Error has already been set for segment type ${segmentType}`);
+function setCell(cell, action) {
+    return new CellState(
+        action.index, action.value, action.readOnly,
+        action.readOnly ? undefined : cell.errors, //todo
+        undefined,
+    );
+}
+
+function clearCell(cell, action) {
+    return new CellState(
+        action.index, action.value, action.readOnly, undefined,
+        recalculateAvailableValues(cell, action),
+    );
+}
+
+function refreshCell(cell, action) {
+    return new CellState(
+        cell.index, cell.value, cell.readOnly, cell.errors,
+        recalculateAvailableValues(cell, action),
+    );
+}
+
+function recalculateAvailableValues(cell, action) {
+    const availableValues = new Set(AVAILABLE_VALUES)
+    availableValues.delete(action.value);
+
+    for (const segmentType of SEGMENT_TYPES) {
+        const segmentIndex = cell.segment(segmentType);
+        const segment = SegmentState.newFrom(action.gridCells, segmentIndex, segmentType);
+
+        for (const segmentCell of segment.cells) {
+            // The old value of the cell should not be removed from availableValues
+            if (!isNaN(segmentCell.value) && segmentCell.index !== action.index) {
+                availableValues.delete(segmentCell.value);
+            }
+        }
     }
-    cell.errors[segmentType] = 1;
-    cell.errors.total += 1;
+    return availableValues;
 }
 
-function clearCellError(cell, segmentType) {
-    if (!cell.errors[segmentType]) {
-        throw new Error(`Error is not set for segment type ${segmentType}`);
-    }
-    cell.errors[segmentType] = 0;
-    cell.errors.total -= 1;
-}
-
-function setCellAvailableValue(cell, value) {
-    cell.availableValues.clear();
-    cell.availableValues.add(value);
-}
-
-function addCellAvailableValue(cell, value) {
-    cell.availableValues.add(value);
-}
-
-function removeCellAvailableValues(cell, values) {
-    for (const value of values) {
-        cell.availableValues.delete(value);
-    }
-}
+// function setCellError(cell, segmentType) {
+//     if (cell.errors[segmentType]) {
+//         throw new Error(`Error has already been set for segment type ${segmentType}`);
+//     }
+//     cell.errors[segmentType] = 1;
+//     cell.errors.total += 1;
+// }
+//
+// function clearCellError(cell, segmentType) {
+//     if (!cell.errors[segmentType]) {
+//         throw new Error(`Error is not set for segment type ${segmentType}`);
+//     }
+//     cell.errors[segmentType] = 0;
+//     cell.errors.total -= 1;
+// }

--- a/src/sudoku/gridReducer.js
+++ b/src/sudoku/gridReducer.js
@@ -1,19 +1,21 @@
+import assert from 'assert';
 import GridState from './GridState';
 import SegmentState from './SegmentState';
 import CellState from './CellState';
 import {SEGMENT_TYPES} from "./Grid";
 
-export function SetValueAction(index, value, gridCells, readOnly) {
+export function SetValueAction(index, value, gridCells, readOnly = false) {
     this.index = index;
     this.value = value;
     this.gridCells = gridCells;
-    this.readOnly = readOnly || false;
+
+    // Used for initialising the grid
+    this.readOnly = readOnly;
 }
 
 export function gridReducer(grid, action) {
-    if (action.constructor !== SetValueAction) {
-        throw new Error(`Invalid action ${action}`);
-    }
+    assert(action.constructor === SetValueAction,
+        `Invalid action '${action.constructor}'`);
 
     // Don't change anything if the action is invalid
     if (action.value < 1 || action.value > 9) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,6 +2525,16 @@ assert@^1.1.1:
     object-assign "^4.1.1"
     util "0.10.3"
 
+assert@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-2.0.0.tgz#95fc1c616d48713510680f2eaf2d10dd22e02d32"
+  integrity sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==
+  dependencies:
+    es6-object-assign "^1.1.0"
+    is-nan "^1.2.1"
+    object-is "^1.0.1"
+    util "^0.12.0"
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"


### PR DESCRIPTION
Made GridState and CellState completely immutable.
Simplified the logic significantly.

Modified the algorithm so that when a cell is modified, the affected
cells get their availableValues completely refreshed instead of just
adding or removing values. This fixes the issue where if the
availableValues get corrupted if you start entering wrong values into
cells.