### PR TITLE
Add back logic to eliminate availableValues more aggressively

### DIFF
--- a/src/sudoku/CellState.js
+++ b/src/sudoku/CellState.js
@@ -58,4 +58,8 @@ export default class CellState {
                 throw new Error(`Unknown segment type '${segmentType}'`);
         }
     }
+
+    nrAvailableValues() {
+        return this.availableValues.size;
+    }
 }


### PR DESCRIPTION
This logic was removed in the last commit while overhauling the reduceGrid module.